### PR TITLE
Upgrade to MQTT 3.1.1

### DIFF
--- a/firmware/MQTT-TLS.cpp
+++ b/firmware/MQTT-TLS.cpp
@@ -92,11 +92,11 @@ bool MQTT::connect(const char *id, const char *user, const char *pass, const cha
 
         if (result) {
             nextMsgId = 1;
-            uint8_t d[9] = {0x00,0x06,'M','Q','I','s','d','p',MQTTPROTOCOLVERSION};
+            uint8_t d[7] = {0x00,0x04,'M','Q','T','T',MQTTPROTOCOLVERSION};
             // Leave room in the buffer for header and variable length field
             uint16_t length = 5;
             unsigned int j;
-            for (j = 0;j<9;j++) {
+            for (j = 0;j<7;j++) {
                 buffer[length++] = d[j];
             }
 

--- a/firmware/MQTT-TLS.h
+++ b/firmware/MQTT-TLS.h
@@ -85,7 +85,7 @@ sample code bearing this copyright.
 // MQTT_KEEPALIVE : keepAlive interval in Seconds
 #define MQTT_KEEPALIVE 15
 
-#define MQTTPROTOCOLVERSION 3
+#define MQTTPROTOCOLVERSION 4
 #define MQTTCONNECT     1 << 4  // Client request to connect to Server
 #define MQTTCONNACK     2 << 4  // Connect Acknowledgment
 #define MQTTPUBLISH     3 << 4  // Publish message


### PR DESCRIPTION
Client won't connect to brokers (now called "servers" in 3.1.1) that support only MQTT 3.1.1. Changing the CONNECT packet header to reflect the new version seems to fix it.