### PR TITLE
feature/set-maxpacketsize

### DIFF
--- a/src/MQTT-TLS.cpp
+++ b/src/MQTT-TLS.cpp
@@ -576,6 +576,13 @@ bool MQTT::isConnected() {
     return rc;
 }
 
+void MQTT::setMaxPacketSize(int maxpacketsize) {
+    this->maxpacketsize = maxpacketsize;
+    if (buffer != NULL)
+      delete[] buffer;
+    buffer = new uint8_t[this->maxpacketsize];
+}
+
 bool MQTT::available() {
     return tcpClient.available();
 }

--- a/src/MQTT-TLS.h
+++ b/src/MQTT-TLS.h
@@ -201,6 +201,8 @@ public:
     bool loop();
     bool isConnected();
 
+    void setMaxPacketSize(int maxpacketsize);
+
     /* TLS */
     bool enableVerify = true;
     int enableTls(const char *rootCaPem, const size_t rootCaPemSize);


### PR DESCRIPTION
The default maxpacketsize (#define MQTT_MAX_PACKET_SIZE 255) is far too small for the IoT use-case we're looking to support given it leverages JSON strings.

The thinking then is adding a setter is one of the better ways to broaden the capability - please let me know if there is another preferred/recommended approach!