### PR TITLE
fix issue #35: variable uninitialized warning

### DIFF
--- a/src/MQTT-TLS.cpp
+++ b/src/MQTT-TLS.cpp
@@ -716,7 +716,7 @@ int MQTT::enableTls(const char *rootCaPem, const size_t rootCaPemSize,
 
 
 int MQTT::handShakeTls() {
-  int ret;
+  int ret = -1;
   debug_tls("hand shake start\n");
   do {
       while (ssl.state != MBEDTLS_SSL_HANDSHAKE_OVER) {


### PR DESCRIPTION
fix issue #35 variable may be used uninitialized warning https://github.com/hirotakaster/MQTT-TLS/issues/35

thanks!